### PR TITLE
Multi config props

### DIFF
--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -37,6 +37,7 @@ from conans.util.log import configure_logger
 from conans.util.tracer import log_command, log_exception
 from conans.client.loader_parse import load_conanfile_class
 from conans.client import settings_preprocessor
+from conans.tools import set_global_instances
 
 default_manifest_folder = '.conan_manifests'
 
@@ -148,8 +149,7 @@ class ConanAPIV1(object):
         self._manager = ConanManager(client_cache, user_io, runner, remote_manager, search_manager,
                                      settings_preprocessor)
         # Patch the tools module with a good requester and user_io
-        tools._global_requester = get_basic_requester(self._client_cache)
-        tools._global_output = self._user_io.out
+        set_global_instances(self._user_io.out, get_basic_requester(self._client_cache))
 
     @api_method
     def new(self, name, header=False, pure_c=False, test=False, exports_sources=False, bare=False, cwd=None,

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -19,12 +19,16 @@ os:
     Android:
         api_level: ANY
     iOS:
-        version: ["7.0", "7.1", "8.0", "8.1", "8.2", "8.3", "9.0", "9.1", "9.2", "9.3", "10.0", "10.1", "10.2", "10.3"]
+        version: ["7.0", "7.1", "8.0", "8.1", "8.2", "8.3", "9.0", "9.1", "9.2", "9.3", "10.0", "10.1", "10.2", "10.3", "11.0"]
+    watchOS:
+        version: ["4.0"]
+    tvOS:
+        version: ["11.0"]
     FreeBSD:
     SunOS:
     Arduino:
         board: ANY
-arch: [x86, x86_64, ppc64le, ppc64, armv6, armv7, armv7hf, armv8, sparc, sparcv9, mips, mips64, avr]
+arch: [x86, x86_64, ppc64le, ppc64, armv6, armv7, armv7hf, armv8, sparc, sparcv9, mips, mips64, avr, armv7s, armv7k]
 compiler:
     sun-cc:
         version: ["5.10", "5.11", "5.12", "5.13", "5.14"]

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -78,6 +78,7 @@ def write_generators(conanfile, path, output):
                 generator = generator_class(conanfile.deps_cpp_info, conanfile.cpp_info)
 
             try:
+                generator.output_path = path
                 content = generator.content
                 if isinstance(content, dict):
                     if generator.filename:

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -87,7 +87,7 @@ class ConanFileLoader(object):
         # It is necessary to copy the settings, because the above is only a constraint of
         # conanfile settings, and a txt doesn't define settings. Necessary for generators,
         # as cmake_multi, that check build_type.
-        conanfile.settings = self._settings.copy()
+        conanfile.settings = self._settings.copy_values()
 
         try:
             parser = ConanFileTextLoader(contents)
@@ -114,7 +114,7 @@ class ConanFileLoader(object):
         # If user don't specify namespace in options, assume that it is
         # for the reference (keep compatibility)
         conanfile = ConanFile(None, self._runner, self._settings.copy(), current_path)
-
+        conanfile.settings = self._settings.copy_values()
         # Assign environment
         conanfile._env_values.update(self._env_values)
 

--- a/conans/client/rest/uploader_downloader.py
+++ b/conans/client/rest/uploader_downloader.py
@@ -113,11 +113,15 @@ class Downloader(object):
         self.requester = requester
         self.verify = verify
 
-    def download(self, url, file_path=None, auth=None, retry=1, retry_wait=0):
+    def download(self, url, file_path=None, auth=None, retry=1, retry_wait=0, overwrite=False):
 
         if file_path and os.path.exists(file_path):
-            # Should not happen, better to raise, probably we had to remove the dest folder before
-            raise ConanException("Error, the file to download already exists: '%s'" % file_path)
+            if overwrite:
+                if self.output:
+                    self.output.warn("file '%s' already exists, overwriting" % file_path)
+            else:
+                # Should not happen, better to raise, probably we had to remove the dest folder before
+                raise ConanException("Error, the file to download already exists: '%s'" % file_path)
 
         t1 = time.time()
         ret = bytearray()

--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -221,3 +221,12 @@ def collect_libs(conanfile, folder="lib"):
                 name = name[3:]
             result.append(name)
     return result
+
+
+def which(filename):
+    """ same affect as posix which command or shutil.which from python3 """
+    for path in os.environ["PATH"].split(os.pathsep):
+        fullname = os.path.join(path, filename)
+        if os.path.exists(fullname) and os.access(fullname, os.X_OK):
+            return os.path.join(path, filename)
+    return None

--- a/conans/client/tools/files.py
+++ b/conans/client/tools/files.py
@@ -118,11 +118,12 @@ def untargz(filename, destination="."):
 def check_with_algorithm_sum(algorithm_name, file_path, signature):
     real_signature = _generic_algorithm_sum(file_path, algorithm_name)
     if real_signature != signature:
-        raise ConanException("%s signature failed for '%s' file."
+        raise ConanException("%s signature failed for '%s' file. \n"
+                             " Provided signature: %s  \n"
                              " Computed signature: %s" % (algorithm_name,
                                                           os.path.basename(file_path),
+                                                          signature,
                                                           real_signature))
-
 
 def check_sha1(file_path, signature):
     check_with_algorithm_sum("sha1", file_path, signature)

--- a/conans/client/tools/net.py
+++ b/conans/client/tools/net.py
@@ -45,12 +45,12 @@ def ftp_download(ip, filename, login='', password=''):
             pass
 
 
-def download(url, filename, verify=True, out=None, retry=2, retry_wait=5):
+def download(url, filename, verify=True, out=None, retry=2, retry_wait=5, overwrite=False):
     out = out or ConanOutput(sys.stdout, True)
     if verify:
         # We check the certificate using a list of known verifiers
         import conans.client.rest.cacert as cacert
         verify = cacert.file_path
     downloader = Downloader(_global_requester, out, verify=verify)
-    downloader.download(url, filename, retry=retry, retry_wait=retry_wait)
+    downloader.download(url, filename, retry=retry, retry_wait=retry_wait, overwrite=overwrite)
     out.writeln("")

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -102,6 +102,9 @@ def vcvars_command(settings):
                 else:
                     raise ConanException("VS2017 '%s' variable not defined, "
                                          "and vswhere didn't find it" % env_var)
+            if not os.path.isdir(vs_path):
+                _global_output.warn('VS variable %s points to the non-existing path "%s",'
+                    'please check that you have set it correctly' % (env_var, vs_path))
             vcvars_path = os.path.join(vs_path, "../../VC/Auxiliary/Build/vcvarsall.bat")
             command = ('set "VSCMD_START_DIR=%%CD%%" && '
                        'call "%s" %s' % (vcvars_path, param))
@@ -110,6 +113,9 @@ def vcvars_command(settings):
                 vs_path = os.environ[env_var]
             except KeyError:
                 raise ConanException("VS '%s' variable not defined. Please install VS" % env_var)
+            if not os.path.isdir(vs_path):
+                _global_output.warn('VS variable %s points to the non-existing path "%s",'
+                    'please check that you have set it correctly' % (env_var, vs_path))
             vcvars_path = os.path.join(vs_path, "../../VC/vcvarsall.bat")
             command = ('call "%s" %s' % (vcvars_path, param))
 

--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -5,23 +5,24 @@ import subprocess
 
 from conans.client.tools.env import environment_append
 from conans.client.tools.files import unix_path
+from conans.client.tools.oss import cpu_count
 from conans.errors import ConanException
 
 _global_output = None
 
 
 def msvc_build_command(settings, sln_path, targets=None, upgrade_project=True, build_type=None,
-                       arch=None):
+                       arch=None, parallel=True):
     """ Do both: set the environment variables and call the .sln build
     """
     vcvars = vcvars_command(settings)
-    build = build_sln_command(settings, sln_path, targets, upgrade_project, build_type, arch)
+    build = build_sln_command(settings, sln_path, targets, upgrade_project, build_type, arch, parallel)
     command = "%s && %s" % (vcvars, build)
     return command
 
 
 def build_sln_command(settings, sln_path, targets=None, upgrade_project=True, build_type=None,
-                      arch=None):
+                      arch=None, parallel=True):
     """
     Use example:
         build_command = build_sln_command(self.settings, "myfile.sln", targets=["SDL2_image"])
@@ -43,6 +44,9 @@ def build_sln_command(settings, sln_path, targets=None, upgrade_project=True, bu
         command += '"x64"' if arch == "x86_64" else '"x86"'
     elif "ARM" in arch.upper():
         command += ' /p:Platform="ARM"'
+
+    if parallel:
+        command += ' /m:%s' % cpu_count()
 
     if targets:
         command += " /target:%s" % ";".join(targets)

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -54,6 +54,18 @@ class SettingsItem(object):
             result._definition = {k: v.copy() for k, v in self._definition.items()}
         return result
 
+    def copy_values(self):
+        if self._value is None and "None" not in self._definition:
+            return None
+
+        result = SettingsItem({}, name=self._name)
+        result._value = self._value
+        if self.is_final:
+            result._definition = self._definition[:]
+        else:
+            result._definition = {k: v.copy_values() for k, v in self._definition.items()}
+        return result
+
     @property
     def is_final(self):
         return not isinstance(self._definition, dict)
@@ -192,6 +204,16 @@ class Settings(object):
         result = Settings({}, name=self._name, parent_value=self._parent_value)
         for k, v in self._data.items():
             result._data[k] = v.copy()
+        return result
+
+    def copy_values(self):
+        """ deepcopy, recursive
+        """
+        result = Settings({}, name=self._name, parent_value=self._parent_value)
+        for k, v in self._data.items():
+            value = v.copy_values()
+            if value is not None:
+                result._data[k] = value
         return result
 
     @staticmethod

--- a/conans/test/functional/default_profile_test.py
+++ b/conans/test/functional/default_profile_test.py
@@ -10,6 +10,24 @@ from conans.util.files import save
 
 class DefaultProfileTest(unittest.TestCase):
 
+    def conanfile_txt_incomplete_profile_test(self):
+        conanfile = '''from conans import ConanFile
+class MyConanfile(ConanFile):
+    pass
+'''
+
+        client = TestClient()
+        save(client.client_cache.default_profile_path, "[env]\nValue1=A")
+
+        client.save({CONANFILE: conanfile})
+        client.run("create Pkg/0.1@lasote/stable")
+        self.assertIn("Pkg/0.1@lasote/stable: Package '5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9' "
+                      "created", client.out)
+
+        client.save({"conanfile.txt": "[requires]\nPkg/0.1@lasote/stable"}, clean_first=True)
+        client.run('install .')
+        self.assertIn("Pkg/0.1@lasote/stable: Already installed!", client.out)
+
     def change_default_profile_test(self):
         br = '''
 import os

--- a/conans/test/model/other_settings_test.py
+++ b/conans/test/model/other_settings_test.py
@@ -148,7 +148,7 @@ class SayConan(ConanFile):
         self.client.save({CONANFILE: content})
         self.client.run("install -s os=ChromeOS --build missing", ignore_error=True)
         self.assertIn(bad_value_msg("settings.os", "ChromeOS",
-                                    ['Android', 'Arduino', 'FreeBSD', 'Linux', 'Macos', 'SunOS', 'Windows', 'iOS']),
+                                    ['Android', 'Arduino', 'FreeBSD', 'Linux', 'Macos', 'SunOS', 'Windows', 'iOS', 'tvOS', 'watchOS']),
                       str(self.client.user_io.out))
 
         # Now add new settings to config and try again

--- a/conans/test/model/transitive_reqs_test.py
+++ b/conans/test/model/transitive_reqs_test.py
@@ -1817,7 +1817,7 @@ class SayConan(ConanFile):
         with self.assertRaises(ConanException) as cm:
             self.root(content, options="arch_independent=True", settings="os=Linux")
         self.assertIn(bad_value_msg("settings.os", "Linux",
-                                    ['Android', 'Arduino', 'FreeBSD', 'Macos', 'SunOS', "Windows", "iOS"]),
+                                    ['Android', 'Arduino', 'FreeBSD', 'Macos', 'SunOS', "Windows", "iOS", "tvOS", "watchOS"]),
                       str(cm.exception))
 
     def test_config_remove2(self):

--- a/conans/test/util/build_sln_command_test.py
+++ b/conans/test/util/build_sln_command_test.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+from conans.tools import build_sln_command, cpu_count
+from conans.errors import ConanException
+from conans.model.settings import Settings
+from nose.plugins.attrib import attr
+
+
+@attr('visual_studio')
+class BuildSLNCommandTest(unittest.TestCase):
+    def no_arch_test(self):
+        with self.assertRaises(ConanException):
+            build_sln_command(Settings({}), sln_path='dummy.sln', targets=None, upgrade_project=False,
+                              build_type='Debug', arch=None, parallel=False)
+
+    def no_build_type_test(self):
+        with self.assertRaises(ConanException):
+            build_sln_command(Settings({}), sln_path='dummy.sln', targets=None, upgrade_project=False,
+                              build_type=None, arch='x86', parallel=False)
+
+    def positive_test(self):
+        command = build_sln_command(Settings({}), sln_path='dummy.sln', targets=None, upgrade_project=False,
+                                    build_type='Debug', arch='x86', parallel=False)
+        self.assertIn('msbuild dummy.sln', command)
+        self.assertIn('/p:Platform="x86"', command)
+        self.assertNotIn('devenv dummy.sln /upgrade', command)
+        self.assertNotIn('/m:%s' % cpu_count(), command)
+        self.assertNotIn('/target:teapot', command)
+
+    def upgrade_test(self):
+        command = build_sln_command(Settings({}), sln_path='dummy.sln', targets=None, upgrade_project=True,
+                                    build_type='Debug', arch='x86_64', parallel=False)
+        self.assertIn('msbuild dummy.sln', command)
+        self.assertIn('/p:Platform="x64"', command)
+        self.assertIn('devenv dummy.sln /upgrade', command)
+        self.assertNotIn('/m:%s' % cpu_count(), command)
+        self.assertNotIn('/target:teapot', command)
+
+    def parallel_test(self):
+        command = build_sln_command(Settings({}), sln_path='dummy.sln', targets=None, upgrade_project=True,
+                                    build_type='Debug', arch='armv7', parallel=False)
+        self.assertIn('msbuild dummy.sln', command)
+        self.assertIn('/p:Platform="ARM"', command)
+        self.assertIn('devenv dummy.sln /upgrade', command)
+        self.assertNotIn('/m:%s' % cpu_count(), command)
+        self.assertNotIn('/target:teapot', command)
+
+    def target_test(self):
+        command = build_sln_command(Settings({}), sln_path='dummy.sln', targets=['teapot'], upgrade_project=False,
+                                    build_type='Debug', arch='x86', parallel=False)
+        self.assertIn('msbuild dummy.sln', command)
+        self.assertIn('/p:Platform="x86"', command)
+        self.assertNotIn('devenv dummy.sln /upgrade', command)
+        self.assertNotIn('/m:%s' % cpu_count(), command)
+        self.assertIn('/target:teapot', command)

--- a/conans/test/util/file_hashes_test.py
+++ b/conans/test/util/file_hashes_test.py
@@ -19,11 +19,11 @@ class HashesTest(unittest.TestCase):
         check_sha1(filepath, "eb599ec83d383f0f25691c184f656d40384f9435")
         check_sha256(filepath, "7365d029861e32c521f8089b00a6fb32daf0615025b69b599d1ce53501b845c2")
 
-        with self.assertRaisesRegexp(ConanException, "md5 signature failed for 'file.txt' file. Computed signature:"):
+        with self.assertRaisesRegexp(ConanException, "md5 signature failed for 'file.txt' file."):
             check_md5(filepath, "invalid")
 
-        with self.assertRaisesRegexp(ConanException, "sha1 signature failed for 'file.txt' file. Computed signature:"):
+        with self.assertRaisesRegexp(ConanException, "sha1 signature failed for 'file.txt' file."):
             check_sha1(filepath, "invalid")
 
-        with self.assertRaisesRegexp(ConanException, "sha256 signature failed for 'file.txt' file. Computed signature:"):
+        with self.assertRaisesRegexp(ConanException, "sha256 signature failed for 'file.txt' file."):
             check_sha256(filepath, "invalid")

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -485,3 +485,16 @@ class HelloConan(ConanFile):
                        retry=3, retry_wait=0)
 
         self.assertTrue(os.path.exists(dest))
+
+        # overwrite = False
+        with self.assertRaises(ConanException):
+            tools.download("http://www.zlib.net/manual.html",
+                           dest, out=out,
+                           retry=3, retry_wait=0, overwrite=False)
+
+        # overwrite = True
+        tools.download("http://www.zlib.net/manual.html",
+                       dest, out=out,
+                       retry=3, retry_wait=0, overwrite=True)
+
+        self.assertTrue(os.path.exists(dest))

--- a/conans/test/util/tools_test.py
+++ b/conans/test/util/tools_test.py
@@ -1,6 +1,5 @@
 import os
 import platform
-import tempfile
 import unittest
 
 from collections import namedtuple
@@ -20,8 +19,10 @@ from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient, TestBufferConanOutput
 from conans.test.utils.visual_project_files import get_vs_project_files
 from conans.test.utils.context_manager import which
-from conans.tools import OSInfo, SystemPackageTool, replace_in_file, AptTool, ChocolateyTool
+from conans.tools import OSInfo, SystemPackageTool, replace_in_file, AptTool, ChocolateyTool,\
+    set_global_instances
 from conans.util.files import save
+import requests
 
 
 class RunnerMock(object):
@@ -74,9 +75,6 @@ class ToolsTest(unittest.TestCase):
     def test_global_tools_overrided(self):
         client = TestClient()
 
-        tools._global_requester = None
-        tools._global_output = None
-
         conanfile = """
 from conans import ConanFile, tools
 
@@ -85,16 +83,14 @@ class HelloConan(ConanFile):
     version = "0.1"
 
     def build(self):
-        assert(tools._global_requester != None)
-        assert(tools._global_output != None)
+        assert(tools.net._global_requester != None)
+        assert(tools.files._global_output != None)
         """
         client.save({"conanfile.py": conanfile})
         client.run("install -g txt")
         client.run("build")
 
         # Not test the real commmand get_command if it's setting the module global vars
-        tools._global_requester = None
-        tools._global_output = None
         tmp = temp_folder()
         conf = default_client_conf.replace("\n[proxies]", "\n[proxies]\nhttp = http://myproxy.com")
         os.mkdir(os.path.join(tmp, ".conan"))
@@ -102,9 +98,8 @@ class HelloConan(ConanFile):
         with tools.environment_append({"CONAN_USER_HOME": tmp}):
             conan_api = ConanAPIV1.factory()
         conan_api.remote_list()
-        self.assertEquals(tools._global_requester.proxies, {"http": "http://myproxy.com"})
-
-        self.assertIsNotNone(tools._global_output.warn)
+        self.assertEquals(tools.net._global_requester.proxies, {"http": "http://myproxy.com"})
+        self.assertIsNotNone(tools.files._global_output.warn)
 
     def test_environment_nested(self):
         with tools.environment_append({"A": "1", "Z": "40"}):
@@ -445,26 +440,26 @@ class HelloConan(ConanFile):
         client.save(files)
         client.run("export lasote/stable")
         client.run("install Hello/1.2.1@lasote/stable --build -s arch=x86_64")
-        self.assertTrue("Release|x64", client.user_io.out)
-        self.assertTrue("Copied 1 '.exe' files: MyProject.exe", client.user_io.out)
+        self.assertIn("Release|x64", client.user_io.out)
+        self.assertIn("Copied 1 '.exe' files: MyProject.exe", client.user_io.out)
 
         # Try with x86
         client.save(files, clean_first=True)
         client.run("export lasote/stable")
         client.run("install Hello/1.2.1@lasote/stable --build -s arch=x86")
-        self.assertTrue("Release|x86", client.user_io.out)
-        self.assertTrue("Copied 1 '.exe' files: MyProject.exe", client.user_io.out)
+        self.assertIn("Release|x86", client.user_io.out)
+        self.assertIn("Copied 1 '.exe' files: MyProject.exe", client.user_io.out)
 
         # Try with x86 debug
         client.save(files, clean_first=True)
         client.run("export lasote/stable")
         client.run("install Hello/1.2.1@lasote/stable --build -s arch=x86 -s build_type=Debug")
-        self.assertTrue("Debug|x86", client.user_io.out)
-        self.assertTrue("Copied 1 '.exe' files: MyProject.exe", client.user_io.out)
+        self.assertIn("Debug|x86", client.user_io.out)
+        self.assertIn("Copied 1 '.exe' files: MyProject.exe", client.user_io.out)
 
     def download_retries_test(self):
         out = TestBufferConanOutput()
-
+        set_global_instances(out, requests)
         # Connection error
         with self.assertRaisesRegexp(ConanException, "HTTPConnectionPool"):
             tools.download("http://fakeurl3.es/nonexists",

--- a/conans/test/util/which_test.py
+++ b/conans/test/util/which_test.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+import os
+import stat
+import platform
+from conans import tools
+from conans.test.utils.test_files import temp_folder
+
+
+class WhichTest(unittest.TestCase):
+    @staticmethod
+    def _touch(filename):
+        with open(filename, 'a'):
+            os.utime(filename, None)
+
+    @staticmethod
+    def _add_executable_bit(filename):
+        if os.name == 'posix':
+            mode = os.stat(filename).st_mode
+            mode |= stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+            os.chmod(filename, stat.S_IMODE(mode))
+
+    def test_which_positive(self):
+        tmp_dir = temp_folder()
+        fullname = os.path.join(tmp_dir, 'example.sh')
+        self._touch(fullname)
+        self._add_executable_bit(fullname)
+        with tools.environment_append({'PATH': tmp_dir}):
+            self.assertEqual(tools.which('example.sh'), fullname)
+
+    def test_which_negative(self):
+        tmp_dir = temp_folder()
+        with tools.environment_append({'PATH': tmp_dir}):
+            self.assertIsNone(tools.which('example.sh'))
+
+    def test_which_non_executable(self):
+        if platform.system() == "Windows":
+            """on Windows we always have executable permissions by default"""
+            return
+        tmp_dir = temp_folder()
+        fullname = os.path.join(tmp_dir, 'example.sh')
+        self._touch(fullname)
+        with tools.environment_append({'PATH': tmp_dir}):
+            self.assertIsNone(tools.which('example.sh'))

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -37,6 +37,7 @@ from conans.test.utils.runner import TestRunner
 from conans.test.utils.test_files import temp_folder
 from conans.util.files import save_files, save
 from conans.util.log import logger
+from conans.tools import set_global_instances
 
 
 class TestingResponse(object):
@@ -388,9 +389,7 @@ class TestClient(object):
         # Handle remote connections
         self.remote_manager = RemoteManager(self.client_cache, auth_manager, self.user_io.out)
 
-        # Patch the globals in tools
-        tools._global_requester = requests
-        tools._global_output = self.user_io.out
+        set_global_instances(output, self.requester)
 
     def init_dynamic_vars(self, user_io=None):
         # Migration system


### PR DESCRIPTION
Sorry the PR includes a merge with develop. The real changes are:

- ``generator.output_path = path``: Passing the path to generators, as they cannot rely on being in the current dir to load the previous ``conanbuildinfo_multi.props`` file.
- Pretification of the .props file, removing extra spaces
- Not adding duplicated nodes to the .props file

Not related to this PR (previous bug, discovered and fixed while playing with the generator):
- ``settings.copy_values()`` to assign those settings that already have values (profile, command line) to conanfile.txt, otherwise, the install without settings can fail.
- Associated test for this bug