### PR TITLE
Add integration test for hard linksPreserve hard links

### DIFF
--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -4,7 +4,7 @@ import shutil
 from collections import defaultdict
 
 from conans.errors import ConanException
-from conans.util.files import mkdir, walk
+from conans.util.files import mkdir, walk, safe_hardlink
 
 
 def report_copied_files(copied, output, message_suffix="Copied"):
@@ -243,13 +243,7 @@ class FileCopier(object):
             else:
                 inode = os.stat(abs_src_name).st_ino
                 if inode in inodes:
-                    try:
-                        os.link(abs_src_name, abs_dst_name)
-                    except OSError as error:
-                        # e.g. OSError: [Errno 18] Invalid cross-device link
-                        raise ConanException(
-                            "Hardlink '{}' pointing to '{}' couldn't be made: {}"
-                            .format(abs_src_name, abs_dst_name, error))
+                    safe_hardlink(abs_src_name, abs_dst_name)
                 else:
                     shutil.copy2(abs_src_name, abs_dst_name)
             copied_files.append(abs_dst_name)

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -7,7 +7,7 @@ from multiprocessing.pool import ThreadPool
 from conans.client import tools
 from conans.client.conanfile.build import run_build_method
 from conans.client.conanfile.package import run_package_method
-from conans.client.file_copier import report_copied_files
+from conans.client.file_copier import report_copied_files, FileCopier
 from conans.client.generators import TXTGenerator
 from conans.client.graph.graph import BINARY_BUILD, BINARY_CACHE, BINARY_DOWNLOAD, BINARY_EDITABLE, \
     BINARY_MISSING, BINARY_SKIP, BINARY_UPDATE, BINARY_UNKNOWN, CONTEXT_HOST
@@ -112,7 +112,9 @@ class _PackageBuilder(object):
         if not getattr(conanfile, 'no_copy_source', False):
             self._output.info('Copying sources to build folder')
             try:
-                shutil.copytree(source_folder, build_folder, symlinks=True)
+                copier = FileCopier([source_folder], build_folder)
+                copier("*", links=True)
+            # Should we preserve same treatment for FileCopier?
             except Exception as e:
                 msg = str(e)
                 if "206" in msg:  # System error shutil.Error 206: Filename or extension too long

--- a/conans/test/integration/hardlinks_test.py
+++ b/conans/test/integration/hardlinks_test.py
@@ -1,0 +1,132 @@
+import os
+import platform
+import unittest
+
+from conans.model.ref import ConanFileReference, PackageReference
+from conans.test.utils.tools import TestClient, TestServer
+from conans.client.tools.files import chdir
+from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID
+
+conanfile = """
+import os
+from conans import ConanFile
+class ExampleConan(ConanFile):
+    name = "example"
+    version = "0.1.0"
+    exports_sources = "*"
+    no_copy_source = True
+    def package(self):
+        {}
+"""
+
+
+@unittest.skipUnless(platform.system() != "Windows", "Requires Hardlinks")
+class HardLinksTest(unittest.TestCase):
+
+    def test_export_source_tgz_hardlink(self):
+        """ Any hardlink MUST be preserved when packaged
+        """
+        file_size = 1024 * 1024
+        client = TestClient(servers={"default": TestServer(write_permissions=[("*/*@*/*", "*")])},
+                            users={"default": [("conan", "password")]})
+        client.save({
+            "conanfile.py": conanfile.replace("{}", 'self.copy("file*", src=self.source_folder)')})
+
+        with chdir(client.current_folder):
+            filename = "file_1MB"
+            with open(filename, "wb") as fd:
+                fd.write(os.urandom(file_size))
+            inode = os.stat(filename).st_ino
+            for i in range(2):
+                linkname = filename + "_link" + str(i + 1)
+                os.link(filename, linkname)
+                link_inode = os.stat(linkname).st_ino
+                self.assertEqual(inode, link_inode)
+
+        client.run("create . conan/testing")
+        self.assertIn("package(): Packaged 3 files", client.out)
+
+        # Each file must be 1MB
+        ref = ConanFileReference("example", "0.1.0", "conan", "testing")
+        pref = PackageReference(ref, NO_SETTINGS_PACKAGE_ID, None)
+        package_folder = client.cache.package_layout(pref.ref).package(pref)
+        download_folder = client.cache.package_layout(pref.ref).download_package(pref)
+        inodes = []
+        for filename in ["file_1MB", "file_1MB_link1", "file_1MB_link2"]:
+            size = os.stat(os.path.join(package_folder, filename)).st_size
+            pkg_inode = os.stat(os.path.join(package_folder, filename)).st_ino
+            self.assertEqual(size, file_size)
+            self.assertEqual(inode, pkg_inode)
+            inodes.append(pkg_inode)
+        # all inodes must be the same
+        self.assertTrue(all(i == inodes[0] for i in inodes))
+
+        client.run("upload * --all --confirm")
+        self.assertIn("Uploading conan_package.tgz", client.out)
+        size = os.stat(os.path.join(download_folder, "conan_package.tgz")).st_size
+        self.assertAlmostEqual(file_size, size, delta=2000)
+
+    def test_weak_point_export_hardlink(self):
+        """ Exporting hardlinks only works when exporting all files at once
+        """
+        file_size = 1024 * 1024
+        client = TestClient(servers={"default": TestServer(write_permissions=[("*/*@*/*", "*")])},
+                            users={"default": [("conan", "password")]})
+
+        client.save({
+            "conanfile.py":
+            conanfile.replace("{}",
+        """self.copy("file_1MB", src=self.source_folder)
+        self.copy("file_1MB_link1", src=self.source_folder)
+        self.copy("file_1MB_link2", src=self.source_folder)
+        """).replace("no_copy_source = True", "no_copy_source = False")})
+
+        with chdir(client.current_folder):
+            filename = "file_1MB"
+            with open(filename, "wb") as fd:
+                fd.write(os.urandom(file_size))
+            inode = os.stat(filename).st_ino
+            for i in range(2):
+                linkname = filename + "_link" + str(i + 1)
+                os.link(filename, linkname)
+                link_inode = os.stat(linkname).st_ino
+                self.assertEqual(inode, link_inode)
+
+        client.run("create . conan/testing")
+        self.assertIn("package(): Packaged 3 files", client.out)
+
+        # Each file must be 1MB
+        ref = ConanFileReference("example", "0.1.0", "conan", "testing")
+        pref = PackageReference(ref, NO_SETTINGS_PACKAGE_ID, None)
+        build_folder = client.cache.package_layout(pref.ref).build(pref)
+        package_folder = client.cache.package_layout(pref.ref).package(pref)
+        download_folder = client.cache.package_layout(pref.ref).download_package(pref)
+        inodes = []
+
+        # Build folder preserves hard links
+        for filename in ["file_1MB", "file_1MB_link1", "file_1MB_link2"]:
+            size = os.stat(os.path.join(build_folder, filename)).st_size
+            pkg_inode = os.stat(os.path.join(build_folder, filename)).st_ino
+            self.assertEqual(size, file_size)
+            # It's a copy, not a hardlink
+            self.assertEqual(inode, pkg_inode)
+            inodes.append(pkg_inode)
+        # all inodes must be the same
+        self.assertTrue(all(i == inodes[0] for i in inodes))
+
+        # Package folder does not preserve hardlink as we copied file by file.
+        # There is no reference to compare. Maybe, compare after copying files and checking with build folder?
+        for filename in ["file_1MB", "file_1MB_link1", "file_1MB_link2"]:
+            size = os.stat(os.path.join(package_folder, filename)).st_size
+            pkg_inode = os.stat(os.path.join(package_folder, filename)).st_ino
+            self.assertEqual(size, file_size)
+            # It's a copy, not a hardlink
+            self.assertNotEqual(inode, pkg_inode)
+            inodes.append(pkg_inode)
+        # all inodes must be the same
+        self.assertFalse(all(i == inodes[0] for i in inodes))
+
+        client.run("upload * --all --confirm")
+        self.assertIn("Uploading conan_package.tgz", client.out)
+        size = os.stat(os.path.join(download_folder, "conan_package.tgz")).st_size
+        self.assertAlmostEqual(3145728, size, delta=2000)

--- a/conans/test/unittests/client/util/files_test.py
+++ b/conans/test/unittests/client/util/files_test.py
@@ -24,6 +24,7 @@ def hardlinks_supported():
     finally:
         shutil.rmtree(tmpdir)
 
+
 class FilesTest(unittest.TestCase):
 
     def test_md5_compress(self):

--- a/conans/test/unittests/client/util/files_test.py
+++ b/conans/test/unittests/client/util/files_test.py
@@ -1,12 +1,28 @@
 import os
+import shutil
 import time
 import unittest
 
 from conans.client.cmd.uploader import compress_files
+from conans.client.tools.files import chdir
 from conans.paths import PACKAGE_TGZ_NAME
 from conans.test.utils.test_files import temp_folder
-from conans.util.files import md5sum, mkdir, path_exists, save
+from conans.util.files import md5sum, mkdir, path_exists, save, save_files
 
+
+def hardlinks_supported():
+    if not hasattr(os, "link"):
+        return False
+    tmpdir = temp_folder()
+    try:
+        save_files(tmpdir, {"a": ""})
+        with chdir(tmpdir):
+            os.link("a", "b")
+            return os.stat("a").st_ino == os.stat("b").st_ino
+    except OSError:
+        return False
+    finally:
+        shutil.rmtree(tmpdir)
 
 class FilesTest(unittest.TestCase):
 
@@ -49,3 +65,33 @@ class FilesTest(unittest.TestCase):
         mkdir(new_path)
         self.assertTrue(path_exists(new_path, tmp_dir))
         self.assertFalse(path_exists(os.path.join(tmp_dir, "capsdir"), tmp_dir))
+
+    @unittest.skipUnless(hardlinks_supported(), "requires hard-links")
+    def test_hard_links(self):
+        """
+        test hard links are preserved during the packaging
+        """
+        tmpdir = temp_folder()
+        a = os.path.join(tmpdir, "one_file.txt")
+        b = os.path.join(tmpdir, "two_file.txt")
+        save(a, b"The contents")
+        os.link(a, b)
+
+        files = {"one_file.txt": a, "two_file.txt": b}
+        compress_files(files, {}, PACKAGE_TGZ_NAME, dest_dir=tmpdir)
+
+        import tarfile
+
+        dst = temp_folder()
+        with tarfile.open(os.path.join(tmpdir, PACKAGE_TGZ_NAME)) as t:
+            t.extractall(dst)
+
+        a = os.path.join(dst, "one_file.txt")
+        b = os.path.join(dst, "two_file.txt")
+
+        md5_a = md5sum(a)
+        md5_b = md5sum(b)
+
+        self.assertEqual(md5_a, md5_b)
+
+        self.assertEqual(os.stat(a).st_ino, os.stat(b).st_ino)

--- a/conans/test/unittests/client/util/files_test.py
+++ b/conans/test/unittests/client/util/files_test.py
@@ -1,28 +1,11 @@
 import os
-import shutil
 import time
 import unittest
 
 from conans.client.cmd.uploader import compress_files
-from conans.client.tools.files import chdir
 from conans.paths import PACKAGE_TGZ_NAME
 from conans.test.utils.test_files import temp_folder
-from conans.util.files import md5sum, mkdir, path_exists, save, save_files
-
-
-def hardlinks_supported():
-    if not hasattr(os, "link"):
-        return False
-    tmpdir = temp_folder()
-    try:
-        save_files(tmpdir, {"a": ""})
-        with chdir(tmpdir):
-            os.link("a", "b")
-            return os.stat("a").st_ino == os.stat("b").st_ino
-    except OSError:
-        return False
-    finally:
-        shutil.rmtree(tmpdir)
+from conans.util.files import md5sum, mkdir, path_exists, save
 
 
 class FilesTest(unittest.TestCase):
@@ -66,33 +49,3 @@ class FilesTest(unittest.TestCase):
         mkdir(new_path)
         self.assertTrue(path_exists(new_path, tmp_dir))
         self.assertFalse(path_exists(os.path.join(tmp_dir, "capsdir"), tmp_dir))
-
-    @unittest.skipUnless(hardlinks_supported(), "requires hard-links")
-    def test_hard_links(self):
-        """
-        test hard links are preserved during the packaging
-        """
-        tmpdir = temp_folder()
-        a = os.path.join(tmpdir, "one_file.txt")
-        b = os.path.join(tmpdir, "two_file.txt")
-        save(a, b"The contents")
-        os.link(a, b)
-
-        files = {"one_file.txt": a, "two_file.txt": b}
-        compress_files(files, {}, PACKAGE_TGZ_NAME, dest_dir=tmpdir)
-
-        import tarfile
-
-        dst = temp_folder()
-        with tarfile.open(os.path.join(tmpdir, PACKAGE_TGZ_NAME)) as t:
-            t.extractall(dst)
-
-        a = os.path.join(dst, "one_file.txt")
-        b = os.path.join(dst, "two_file.txt")
-
-        md5_a = md5sum(a)
-        md5_b = md5sum(b)
-
-        self.assertEqual(md5_a, md5_b)
-
-        self.assertEqual(os.stat(a).st_ino, os.stat(b).st_ino)

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -435,10 +435,16 @@ def merge_directories(src, dst, excluded=None):
         dst_dir = os.path.normpath(os.path.join(dst, os.path.relpath(src_dir, src)))
         if not os.path.exists(dst_dir):
             os.makedirs(dst_dir)
+
+        inodes = [os.stat(os.path.join(src_dir, filename)).st_ino for filename in files]
+        inodes = set([node for node in inodes if inodes.count(node) > 1])
+
         for file_ in files:
             src_file = os.path.join(src_dir, file_)
             dst_file = os.path.join(dst_dir, file_)
             if os.path.islink(src_file):
                 link_to_rel(src_file)
+            elif os.stat(os.path.join(src_dir, file_)).st_ino in inodes:
+                os.link(src_file, dst_file)
             else:
                 shutil.copy2(src_file, dst_file)

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -389,6 +389,16 @@ def exception_message_safe(exc):
         return decode_text(repr(exc))
 
 
+def safe_hardlink(src_file, dst_file):
+    """ Generate a hard link, or a file copy if it fails
+    """
+    try:
+        os.link(src_file, dst_file)
+    except OSError:
+        # e.g. OSError: [Errno 18] Invalid cross-device link
+        shutil.copy2(src_file, dst_file)
+
+
 def merge_directories(src, dst, excluded=None):
     src = os.path.normpath(src)
     dst = os.path.normpath(dst)
@@ -445,6 +455,6 @@ def merge_directories(src, dst, excluded=None):
             if os.path.islink(src_file):
                 link_to_rel(src_file)
             elif os.stat(os.path.join(src_dir, file_)).st_ino in inodes:
-                os.link(src_file, dst_file)
+                safe_hardlink(src_file, dst_file)
             else:
                 shutil.copy2(src_file, dst_file)


### PR DESCRIPTION
Privet @SSE4 !!

I've added some changes to your work.

First, `uploader` is only the top of the iceberg, when are packaging to upload from package folder, all files there are copies already.

As we can see, I needed to update more parts, to detect hard links and preserve them. Copying from source folder to build folder and build to package are different flows and require different methods.
I also added a functional test to validate all conan create flow, it reproduces the original bug reported by the user.

There is only one case which we can't prevent for now, and maybe we should not fix:

When we pass `self.copy("*")` we are passing a list of files, so we can compare if there is a hard link on the origin, in middle of those files listed to be copied.
However, if we copy file by file, we can't compare directly, we would need to do a post package verification, like checking if a file in package folder is the same than in build folder or source folder (no_copy_sources case) and if it's a hard link on the origin. I think it's too much.

