### PR TITLE
Collect nodes before processing

### DIFF
--- a/conans/client/file_copier.py
+++ b/conans/client/file_copier.py
@@ -222,8 +222,7 @@ class FileCopier(object):
         managing symlinks if necessary
         """
         copied_files = []
-        inodes = [os.stat(os.path.join(src, filename)).st_ino for filename in files]
-        inodes = set([node for node in inodes if inodes.count(node) > 1])
+        inodes = {}
 
         for filename in files:
             abs_src_name = os.path.join(src, filename)
@@ -243,8 +242,10 @@ class FileCopier(object):
             else:
                 inode = os.stat(abs_src_name).st_ino
                 if inode in inodes:
-                    safe_hardlink(abs_src_name, abs_dst_name)
+                    safe_hardlink(inodes[inode], abs_dst_name)
                 else:
                     shutil.copy2(abs_src_name, abs_dst_name)
+                    inodes[inode] = abs_dst_name
+
             copied_files.append(abs_dst_name)
         return copied_files

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -113,15 +113,16 @@ class _PackageBuilder(object):
         if not getattr(conanfile, 'no_copy_source', False):
             self._output.info('Copying sources to build folder')
             try:
-                inodes = dict()
+                files = os.listdir(source_folder)
+                inodes = [os.stat(os.path.join(source_folder, filename)).st_ino for filename in files]
+                inodes = set([node for node in inodes if inodes.count(node) > 1])
 
                 def copy_or_link(srcname, dstname):
                     inode = os.stat(srcname).st_ino
                     if inode in inodes:
-                        safe_hardlink(inodes[inode], dstname)
+                        safe_hardlink(srcname, dstname)
                     else:
                         shutil.copy2(srcname, dstname)
-                        inodes[inode] = dstname
 
                 def copytree_or_link(src, dst):
                     if not os.path.exists(dst):

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -113,16 +113,15 @@ class _PackageBuilder(object):
         if not getattr(conanfile, 'no_copy_source', False):
             self._output.info('Copying sources to build folder')
             try:
-                files = os.listdir(source_folder)
-                inodes = [os.stat(os.path.join(source_folder, filename)).st_ino for filename in files]
-                inodes = set([node for node in inodes if inodes.count(node) > 1])
+                inodes = dict()
 
                 def copy_or_link(srcname, dstname):
                     inode = os.stat(srcname).st_ino
                     if inode in inodes:
-                        safe_hardlink(srcname, dstname)
+                        safe_hardlink(inodes[inode], dstname)
                     else:
                         shutil.copy2(srcname, dstname)
+                        inodes[inode] = dstname
 
                 def copytree_or_link(src, dst):
                     if not os.path.exists(dst):

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -446,15 +446,16 @@ def merge_directories(src, dst, excluded=None):
         if not os.path.exists(dst_dir):
             os.makedirs(dst_dir)
 
-        inodes = [os.stat(os.path.join(src_dir, filename)).st_ino for filename in files]
-        inodes = set([node for node in inodes if inodes.count(node) > 1])
+        inodes = {}
 
         for file_ in files:
             src_file = os.path.join(src_dir, file_)
             dst_file = os.path.join(dst_dir, file_)
+            inode = os.stat(src_file).st_ino
             if os.path.islink(src_file):
                 link_to_rel(src_file)
-            elif os.stat(os.path.join(src_dir, file_)).st_ino in inodes:
-                safe_hardlink(src_file, dst_file)
+            elif inode in inodes:
+                safe_hardlink(inodes[inode], dst_file)
             else:
                 shutil.copy2(src_file, dst_file)
+                inodes[inode] = dst_file


### PR DESCRIPTION
We have to collect all inodes before checking, otherwise, the first inode won't be present in the list and copied as a new file.